### PR TITLE
hardcode arm64 to use darwin-x64 binary

### DIFF
--- a/zsh-histdb-skim.zsh
+++ b/zsh-histdb-skim.zsh
@@ -9,6 +9,9 @@ histdb-skim-get-os(){
   if [[ ( $UNAME_STR =~ '.*Darwin.*' ) && ( $UNAME_STR =~ '.*x86_64.*') ]]; then
     echo -n "darwin-x64"
   fi
+  if [[ ( $UNAME_STR =~ '.*Darwin.*' ) && ( $UNAME_STR =~ '.*arm64.*') ]]; then
+    echo -n "darwin-x64"
+  fi
   if [[ ( $UNAME_STR =~ '.*Linux.*' ) && ( $UNAME_STR =~ '.*x86_64.*') ]]; then
     echo -n "linux-x64"
   fi


### PR DESCRIPTION
trying to install this on my m1 mac and found it doesn't work by default 
but I found I can still run the darwin-x64 binary, so just adding this as a temporary solution until you have an arm64 binary 😆