### PR TITLE
feat: show duration in "00h 00m 00s" formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,6 +1173,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "enum-map",
+ "humantime",
  "log",
  "regex",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ chrono = "0.4.19"
 enum-map = "2.1.0"
 log = "0.4"
 textwrap = "0.15"
+humantime = "2.1.0"
 
 [dev-dependencies]
 regex = "*"

--- a/src/history.rs
+++ b/src/history.rs
@@ -4,6 +4,8 @@ use chrono::NaiveDateTime;
 use skim::prelude::*;
 use std::time::SystemTime;
 use textwrap::fill;
+use std::time::Duration;
+use humantime::format_duration;
 
 fn get_epoch_start_of_day() -> u64 {
     let now = SystemTime::now();
@@ -61,6 +63,15 @@ impl History {
             "\x1b[37;1m<NONE>\x1b[0m".to_string()
         }
     }
+
+    fn format_duration(&self) -> String {
+        if self.duration.is_some() {
+            let duration = Duration::from_secs(self.duration.unwrap() as u64);
+            format_duration(duration).to_string()
+        } else {
+            History::format_or_none(self.duration)
+        }
+    }
 }
 
 impl SkimItem for History {
@@ -76,7 +87,7 @@ impl SkimItem for History {
             information.push_str(&format!("\x1b[1m{:20}\x1b[0m{}\n", name, value));
         };
 
-        tformat("Runtime", &History::format_or_none(self.duration));
+        tformat("Runtime", &self.format_duration());
         tformat("Host", &self.host);
         tformat("Executed", &self.count.to_string());
         tformat("Directory", &self.dir);


### PR DESCRIPTION
Show the duration in the preview pane in a more human readable form.
e.g. 16 => "16s"
e.g. 75 => "1m 15s" etc