### PR TITLE
add vendored script

### DIFF
--- a/zsh-histdb-skim-vendored.zsh
+++ b/zsh-histdb-skim-vendored.zsh
@@ -1,0 +1,23 @@
+#!/usr/bin/env zsh
+
+histdb-skim-widget() {
+  origquery=${BUFFER}
+  output=$( \
+    HISTDB_HOST=${HISTDB_HOST:-"'$(sql_escape ${HOST})'"} \
+    HISTDB_SESSION=$HISTDB_SESSION \
+    HISTDB_FILE=$HISTDB_FILE \
+    zsh-histdb-skim "$origquery"\
+  )
+
+  if [ $? -eq 0 ]; then
+    BUFFER=$output
+  else
+    BUFFER=$origquery
+  fi
+
+  CURSOR=$#BUFFER
+  zle redisplay
+}
+
+zle     -N   histdb-skim-widget
+bindkey '^R' histdb-skim-widget


### PR DESCRIPTION
When packaged by a package manager, it's not ideal to support automatic updating. Ship an additional file that can be used

* without the support of autoupdate / autofetch
* with the binary simply expected to exist somewhere in $PATH.