### PR TITLE
fix: default tab behavior

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ struct SelectionResult {
 
 fn get_starting_location() -> Location {
     let mut location = get_default_tab();
-    if get_current_session_id() == "" {
+    if location == Location::Session && get_current_session_id() == "" {
         location = Location::Directory;
     }
     location


### PR DESCRIPTION
Fallback to directory behavior only if the tab is session and there is no current session